### PR TITLE
docs: fix spacing repository description

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -3,7 +3,7 @@
 
 repository:
   name: hallmark
-  description: Custom wirelessHall Effect 36-key split keyboard
+  description: Custom wireless Hall Effect 36-key split keyboard
   homepage: ""
   topics: keyboard, hall-effect, nrf52840, zephyr, split-keyboard
   private: false


### PR DESCRIPTION
## What

Missing space in the repository description.

## Why



## Scope

- [ ] Firmware
- [ ] PCB / hardware
- [ ] Case / enclosure
- [x] Docs
- [ ] Tooling / CI

## How to verify



## Related issues

