### PR TITLE
Setup branch protection for main and dev

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -27,7 +27,21 @@ branches:
         dismiss_stale_reviews: true
         require_code_owner_reviews: false
       required_status_checks: null
-      enforce_admins: false
+      enforce_admins: true
+      required_conversation_resolution: false
+      restrictions: null
+      allow_force_pushes: false
+      allow_deletions: false
+      required_linear_history: true
+
+  - name: dev
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 0
+        dismiss_stale_reviews: true
+        require_code_owner_reviews: false
+      required_status_checks: null
+      enforce_admins: true
       required_conversation_resolution: false
       restrictions: null
       allow_force_pushes: false


### PR DESCRIPTION
## What

Add branch protection rules for `dev`, enforce admin protection on `main`.

## Why

`main` had `enforce_admins: false`, allowing protection rules to be bypassed. `dev` had no protection at all, meaning direct pushes were possible.

## Scope

- [ ] Firmware
- [ ] PCB / hardware
- [ ] Case / enclosure
- [ ] Docs
- [x] Tooling / CI

## How to verify

1. Open `settings.yml` and confirm:
   - `main` branch has `enforce_admins: true`
   - `dev` branch protection block exists with matching rules (require PRs, linear history, no force push/deletion, admin enforcement)
2. After merge, verify on GitHub: Settings > Branches shows protection rules active on both `main` and `dev`

## Related issues

Closes #44 
