### PR TITLE
Add clang-format and editorconfig for code style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,72 @@
+# Hallmark — K&R style, 4-space indent, Zephyr extras
+---
+BasedOnStyle: LLVM
+
+# Layout
+IndentWidth: 4
+UseTab: Never
+ColumnLimit: 100
+BreakBeforeBraces: Linux
+ContinuationIndentWidth: 8
+IndentCaseLabels: false
+IndentGotoLabels: false
+InsertBraces: true
+InsertNewlineAtEOF: true
+
+# Disable compact forms
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+
+# Alignment and spacing
+AlignConsecutiveMacros: AcrossComments
+BitFieldColonSpacing: After
+SpaceBeforeParens: ControlStatementsExceptControlMacros
+
+# Zephyr attribute macros
+AttributeMacros:
+  - __aligned
+  - __deprecated
+  - __packed
+  - __printf_like
+  - __syscall
+  - __syscall_always_inline
+  - __subsystem
+
+# Zephyr iteration macros (expand as needed)
+ForEachMacros:
+  - ARRAY_FOR_EACH
+  - ARRAY_FOR_EACH_PTR
+  - FOR_EACH
+  - FOR_EACH_FIXED_ARG
+  - FOR_EACH_IDX
+  - FOR_EACH_IDX_FIXED_ARG
+  - K_SPINLOCK
+  - STRUCT_SECTION_FOREACH
+  - STRUCT_SECTION_FOREACH_ALTERNATE
+  - SYS_SLIST_FOR_EACH_NODE
+  - SYS_SLIST_FOR_EACH_NODE_SAFE
+  - SYS_DLIST_FOR_EACH_NODE
+  - SYS_DLIST_FOR_EACH_NODE_SAFE
+
+IfMacros:
+  - CHECKIF
+
+# Includes — manual ordering, grouped by tier
+SortIncludes: Never
+IncludeCategories:
+  - Regex: '^".*\.h"$'
+    Priority: 0
+  - Regex: '^<zephyr/.*\.h>$'
+    Priority: 1
+  - Regex: '.*'
+    Priority: 2
+
+# Whitespace-sensitive macros
+WhitespaceSensitiveMacros:
+  - COND_CODE_0
+  - COND_CODE_1
+  - STRINGIFY

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,32 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.{c,h}]
+indent_style = space
+indent_size = 4
+
+[*.{dts,dtsi,overlay}]
+indent_style = tab
+tab_width = 8
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = false
+
+[Kconfig*]
+indent_style = tab
+tab_width = 8
+
+[CMakeLists.txt]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 .DS_Store
 
 # Project
+build/
 tmp/


### PR DESCRIPTION
<!-- Base branch: set to `dev` (not `main`) before opening this PR. -->

## What

Add `.clang-format` and `.editorconfig` to establish code style before writing the firmware modules.

## Why

~3,500 lines of firmware are planned. Locking down code style now avoids reformatting churn later and ensures consistency from the first module onward.

## Scope

- [ ] Firmware
- [ ] PCB / hardware
- [ ] Case / enclosure
- [ ] Docs
- [x] Tooling / CI

## How to verify

1. Confirm `.clang-format` exists at repo root with K&R style settings (4-space indent, Linux braces, 100-column limit, mandatory braces)
2. Confirm `.editorconfig` exists with correct per-filetype settings (C: 4-space, devicetree: tabs, YAML: 2-space, etc.)
3. Run `clang-format -style=file --dry-run firmware/src/main.c` (on the nrf-sdk branch) to verify formatting applies cleanly

## Related issues

Closes #46