### PR TITLE
Add release PR template for dev to main merges

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -1,0 +1,21 @@
+## Release vX.Y.Z
+
+### Summary
+
+<!-- High-level description of what this release includes. -->
+
+### Changes
+
+<!-- List the PRs included since the last release. -->
+
+- #__ — Description
+
+### Breaking changes
+
+<!-- Any changes that break previous behavior. Write "None" if not applicable. -->
+
+None
+
+### Post-merge
+
+- [ ] Tag: `git tag -a vX.Y.Z -m "description" && git push origin vX.Y.Z`


### PR DESCRIPTION
<!-- Base branch: set to `dev` (not `main`) before opening this PR. -->

## What

Add a release PR template at `.github/PULL_REQUEST_TEMPLATE/release.md` for `dev` → `main` merges.

## Why

The existing PR template is designed for feature branches → `dev` (scope checkboxes, verification steps, issue linking). Release merges need different sections: version number, accumulated changes, breaking changes, and a post-merge tag checklist.

## Scope

- [ ] Firmware
- [ ] PCB / hardware
- [ ] Case / enclosure
- [ ] Docs
- [x] Tooling / CI

## How to verify

1. Confirm `.github/PULL_REQUEST_TEMPLATE/release.md` exists with release-appropriate sections (version, summary, changes, breaking changes, post-merge checklist)
2. Confirm the default template (`.github/PULL_REQUEST_TEMPLATE.md`) is unchanged
3. Verify the release template is selectable via URL: `https://github.com/flwrenn/hallmark/compare/main...dev?template=release.md`

## Related issues

Closes #48