### PR TITLE
Add PR merge housekeeping workflow, disable auto-delete

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -15,7 +15,7 @@ repository:
   allow_squash_merge: true
   allow_merge_commit: false
   allow_rebase_merge: true
-  delete_branch_on_merge: true
+  delete_branch_on_merge: false
   enable_automated_security_fixes: true
   enable_vulnerability_alerts: true
 

--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -18,11 +18,20 @@ jobs:
         with:
           script: |
             const body = context.payload.pull_request.body || '';
-            const pattern = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
+            const pattern = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
             const matches = [...body.matchAll(pattern)];
             for (const match of matches) {
               const issue_number = parseInt(match[1], 10);
               try {
+                const { data: issue } = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number
+                });
+                if (issue.pull_request) {
+                  console.log(`Skipping #${issue_number} (pull request, not issue)`);
+                  continue;
+                }
                 await github.rest.issues.update({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
@@ -40,7 +49,13 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const branch = context.payload.pull_request.head.ref;
+            const head = context.payload.pull_request.head;
+            const baseRepo = context.payload.pull_request.base.repo.full_name;
+            if (head.repo.full_name !== baseRepo) {
+              console.log(`Skipping deletion: ${head.ref} (fork: ${head.repo.full_name})`);
+              return;
+            }
+            const branch = head.ref;
             const prefixes = ['feat/', 'fix/', 'refactor/', 'docs/', 'chore/', 'test/', 'hotfix/'];
             if (!prefixes.some(p => branch.startsWith(p))) {
               console.log(`Skipping deletion: ${branch} (no matching prefix)`);

--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -17,11 +17,17 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const head = context.payload.pull_request.head;
+            const baseRepo = context.payload.pull_request.base.repo.full_name;
+            if (head.repo.full_name !== baseRepo) {
+              console.log(`Skipping issue closure: fork PR (${head.repo.full_name})`);
+              return;
+            }
             const body = context.payload.pull_request.body || '';
             const pattern = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
             const matches = [...body.matchAll(pattern)];
-            for (const match of matches) {
-              const issue_number = parseInt(match[1], 10);
+            const issueNumbers = [...new Set(matches.map(m => parseInt(m[1], 10)))];
+            for (const issue_number of issueNumbers) {
               try {
                 const { data: issue } = await github.rest.issues.get({
                   owner: context.repo.owner,

--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -1,0 +1,58 @@
+name: PR merge housekeeping
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [dev, main]
+
+jobs:
+  housekeeping:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: write
+    steps:
+      - name: Close referenced issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            const pattern = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
+            const matches = [...body.matchAll(pattern)];
+            for (const match of matches) {
+              const issue_number = parseInt(match[1]);
+              try {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number,
+                  state: 'closed',
+                  state_reason: 'completed'
+                });
+                console.log(`Closed issue #${issue_number}`);
+              } catch (error) {
+                console.log(`Failed to close #${issue_number}: ${error.message}`);
+              }
+            }
+
+      - name: Delete feature branch
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = context.payload.pull_request.head.ref;
+            const prefixes = ['feat/', 'fix/', 'refactor/', 'docs/', 'chore/', 'test/', 'hotfix/'];
+            if (!prefixes.some(p => branch.startsWith(p))) {
+              console.log(`Skipping deletion: ${branch} (no matching prefix)`);
+              return;
+            }
+            try {
+              await github.rest.git.deleteRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `heads/${branch}`
+              });
+              console.log(`Deleted branch: ${branch}`);
+            } catch (error) {
+              console.log(`Failed to delete ${branch}: ${error.message}`);
+            }

--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -21,7 +21,7 @@ jobs:
             const pattern = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
             const matches = [...body.matchAll(pattern)];
             for (const match of matches) {
-              const issue_number = parseInt(match[1]);
+              const issue_number = parseInt(match[1], 10);
               try {
                 await github.rest.issues.update({
                   owner: context.repo.owner,


### PR DESCRIPTION
<!-- Base branch: set to `dev` (not `main`) before opening this PR. -->

## What

Replace `delete_branch_on_merge` with a GitHub Actions workflow that handles post-merge housekeeping: auto-closing issues and deleting feature branches.

## Why

Two problems with the current setup:

1. **Issues don't auto-close** — GitHub's closing keywords (`Closes #X`) only work when merging into the default branch (`main`), but PRs target `dev`.
2. **`delete_branch_on_merge` deletes `dev`** — When merging `dev` → `main`, GitHub auto-deletes `dev` because it's the head branch. Branch protection doesn't prevent this.

## Scope

- [ ] Firmware
- [ ] PCB / hardware
- [ ] Case / enclosure
- [ ] Docs
- [x] Tooling / CI

## How to verify

1. Confirm `delete_branch_on_merge` is `false` in `settings.yml`
2. Review `.github/workflows/pr-merge.yml`:
   - Triggers on PR merge to `dev` or `main`
   - Step 1: Parses PR body for closing keywords, closes referenced issues
   - Step 2: Deletes head branch only if it matches a known prefix (`feat/`, `fix/`, `refactor/`, `docs/`, `chore/`, `test/`, `hotfix/`). Skips `dev`, `main`, and any unrecognized branch.
3. After merge: verify this PR's branch (`chore/51-add-pr-merge-workflow`) is auto-deleted and issue #51 is auto-closed by the workflow

## Related issues

Closes #51