### PR TITLE
Auto-set end date on project items when PR closes issues

### DIFF
--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -13,20 +13,30 @@ jobs:
       issues: write
       contents: write
     steps:
-      - name: Close referenced issues
+      - name: Parse referenced issues
+        id: parse-issues
         uses: actions/github-script@v7
         with:
           script: |
             const head = context.payload.pull_request.head;
             const baseRepo = context.payload.pull_request.base.repo.full_name;
             if (head.repo.full_name !== baseRepo) {
-              console.log(`Skipping issue closure: fork PR (${head.repo.full_name})`);
+              console.log(`Skipping: fork PR (${head.repo.full_name})`);
+              core.setOutput('issues', '[]');
               return;
             }
             const body = context.payload.pull_request.body || '';
             const pattern = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
             const matches = [...body.matchAll(pattern)];
             const issueNumbers = [...new Set(matches.map(m => parseInt(m[1], 10)))];
+            core.setOutput('issues', JSON.stringify(issueNumbers));
+
+      - name: Close referenced issues
+        if: steps.parse-issues.outputs.issues != '[]'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issueNumbers = JSON.parse('${{ steps.parse-issues.outputs.issues }}');
             for (const issue_number of issueNumbers) {
               try {
                 const { data: issue } = await github.rest.issues.get({
@@ -52,22 +62,19 @@ jobs:
             }
 
       - name: Set end date on project items
-        if: ${{ secrets.PROJECT_TOKEN != '' }}
+        if: steps.parse-issues.outputs.issues != '[]'
         uses: actions/github-script@v7
         env:
+          # Hallmark project (users/flwrenn/projects/12)
+          # Find via: gh project list --owner flwrenn --format json
           PROJECT_ID: PVT_kwHOBh2HNc4BPjfG
+          # "End date" custom field
+          # Find via: gh project field-list 12 --owner flwrenn --format json
           END_DATE_FIELD_ID: PVTF_lAHOBh2HNc4BPjfGzg97glk
         with:
           github-token: ${{ secrets.PROJECT_TOKEN }}
           script: |
-            const body = context.payload.pull_request.body || '';
-            const pattern = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
-            const matches = [...body.matchAll(pattern)];
-            const issueNumbers = [...new Set(matches.map(m => parseInt(m[1], 10)))];
-            if (issueNumbers.length === 0) {
-              console.log('No referenced issues found');
-              return;
-            }
+            const issueNumbers = JSON.parse('${{ steps.parse-issues.outputs.issues }}');
             const mergeDate = context.payload.pull_request.merged_at.split('T')[0];
             const projectId = process.env.PROJECT_ID;
             const fieldId = process.env.END_DATE_FIELD_ID;
@@ -82,6 +89,8 @@ jobs:
                   console.log(`Skipping #${issue_number} (pull request)`);
                   continue;
                 }
+                // first: 10 is sufficient — issues are rarely in more than
+                // a handful of projects, especially in a personal repo.
                 const result = await github.graphql(`
                   query($nodeId: ID!) {
                     node(id: $nodeId) {

--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -51,6 +51,75 @@ jobs:
               }
             }
 
+      - name: Set end date on project items
+        if: ${{ secrets.PROJECT_TOKEN != '' }}
+        uses: actions/github-script@v7
+        env:
+          PROJECT_ID: PVT_kwHOBh2HNc4BPjfG
+          END_DATE_FIELD_ID: PVTF_lAHOBh2HNc4BPjfGzg97glk
+        with:
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+          script: |
+            const body = context.payload.pull_request.body || '';
+            const pattern = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
+            const matches = [...body.matchAll(pattern)];
+            const issueNumbers = [...new Set(matches.map(m => parseInt(m[1], 10)))];
+            if (issueNumbers.length === 0) {
+              console.log('No referenced issues found');
+              return;
+            }
+            const mergeDate = context.payload.pull_request.merged_at.split('T')[0];
+            const projectId = process.env.PROJECT_ID;
+            const fieldId = process.env.END_DATE_FIELD_ID;
+            for (const issue_number of issueNumbers) {
+              try {
+                const { data: issue } = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number
+                });
+                if (issue.pull_request) {
+                  console.log(`Skipping #${issue_number} (pull request)`);
+                  continue;
+                }
+                const result = await github.graphql(`
+                  query($nodeId: ID!) {
+                    node(id: $nodeId) {
+                      ... on Issue {
+                        projectItems(first: 10) {
+                          nodes { id project { id } }
+                        }
+                      }
+                    }
+                  }
+                `, { nodeId: issue.node_id });
+                const items = result.node.projectItems.nodes;
+                const projectItem = items.find(i => i.project.id === projectId);
+                if (!projectItem) {
+                  console.log(`#${issue_number} not in project, skipping`);
+                  continue;
+                }
+                await github.graphql(`
+                  mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $date: Date!) {
+                    updateProjectV2ItemFieldValue(input: {
+                      projectId: $projectId
+                      itemId: $itemId
+                      fieldId: $fieldId
+                      value: { date: $date }
+                    }) { projectV2Item { id } }
+                  }
+                `, {
+                  projectId,
+                  itemId: projectItem.id,
+                  fieldId,
+                  date: mergeDate
+                });
+                console.log(`Set end date ${mergeDate} on #${issue_number}`);
+              } catch (error) {
+                console.log(`Failed to update #${issue_number}: ${error.message}`);
+              }
+            }
+
       - name: Delete feature branch
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
## What

Adds a new step to the `pr-merge.yml` workflow that automatically sets the
**end date** field on GitHub Project items when a merged PR closes referenced
issues.

## Why

Currently, end dates on project items must be set manually. This automates it
so the Hallmark project timeline stays accurate without extra effort.

## Scope

- [ ] Firmware
- [ ] PCB / hardware
- [ ] Case / enclosure
- [ ] Docs
- [x] Tooling / CI

## How to verify

1. Create a test issue and add it to the Hallmark project
2. Open a PR referencing the issue with `closes #N`
3. Merge the PR into `dev`
4. Verify the issue's end date in the project is set to the merge date

Requires the `PROJECT_TOKEN` repo secret (classic PAT with `public_repo` +
`project` scopes). The step silently skips if the secret is not configured.

## Related issues

Closes #61