### PR TITLE
Add host-native test infrastructure (Unity + CTest)

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,8 +15,7 @@ set(FETCHCONTENT_UPDATES_DISCONNECTED_UNITY ON)
 FetchContent_Declare(
     unity
     GIT_REPOSITORY https://github.com/ThrowTheSwitch/Unity.git
-    GIT_TAG        v2.6.1
-    GIT_SHALLOW    TRUE
+    GIT_TAG        cbcd08fa7de711053a3deec6339ee89cad5d2697 # v2.6.1
 )
 FetchContent_MakeAvailable(unity)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,7 +7,11 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 # -------------------------------------------------------------------
 # Unity test framework (embedded C standard)
 # -------------------------------------------------------------------
+# After the initial clone, skip network access on reconfigure.
+# For fully offline or vendored builds, configure with:
+#   -DFETCHCONTENT_SOURCE_DIR_UNITY=/path/to/unity
 include(FetchContent)
+set(FETCHCONTENT_UPDATES_DISCONNECTED_UNITY ON)
 FetchContent_Declare(
     unity
     GIT_REPOSITORY https://github.com/ThrowTheSwitch/Unity.git

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,42 @@
+cmake_minimum_required(VERSION 3.20)
+project(hallmark_tests C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+# -------------------------------------------------------------------
+# Unity test framework (embedded C standard)
+# -------------------------------------------------------------------
+include(FetchContent)
+FetchContent_Declare(
+    unity
+    GIT_REPOSITORY https://github.com/ThrowTheSwitch/Unity.git
+    GIT_TAG        v2.6.1
+    GIT_SHALLOW    TRUE
+)
+FetchContent_MakeAvailable(unity)
+
+# -------------------------------------------------------------------
+# Shared algorithm library -- pure C, no RTOS dependencies
+# -------------------------------------------------------------------
+set(FIRMWARE_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../firmware/src)
+
+# Collect algorithm sources (exclude main.c which is the Zephyr app)
+file(GLOB ALGO_SOURCES ${FIRMWARE_SRC_DIR}/*.c)
+list(FILTER ALGO_SOURCES EXCLUDE REGEX "main\\.c$")
+
+if(ALGO_SOURCES)
+    add_library(hallmark_algorithms STATIC ${ALGO_SOURCES})
+    target_include_directories(hallmark_algorithms PUBLIC ${FIRMWARE_SRC_DIR})
+else()
+    # No algorithm sources yet -- create an interface-only target
+    add_library(hallmark_algorithms INTERFACE)
+    target_include_directories(hallmark_algorithms INTERFACE ${FIRMWARE_SRC_DIR})
+endif()
+
+# -------------------------------------------------------------------
+# Test suites
+# -------------------------------------------------------------------
+enable_testing()
+
+add_subdirectory(smoke)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,9 +21,8 @@ FetchContent_MakeAvailable(unity)
 # -------------------------------------------------------------------
 set(FIRMWARE_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../firmware/src)
 
-# Collect algorithm sources (exclude main.c which is the Zephyr app)
-file(GLOB ALGO_SOURCES ${FIRMWARE_SRC_DIR}/*.c)
-list(FILTER ALGO_SOURCES EXCLUDE REGEX "main\\.c$")
+# Algorithm sources -- list new modules here explicitly
+set(ALGO_SOURCES)
 
 if(ALGO_SOURCES)
     add_library(hallmark_algorithms STATIC ${ALGO_SOURCES})

--- a/tests/smoke/CMakeLists.txt
+++ b/tests/smoke/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_executable(test_smoke test_smoke.c)
-target_link_libraries(test_smoke PRIVATE unity)
+target_link_libraries(test_smoke PRIVATE unity hallmark_algorithms)
 
-add_test(NAME smoke COMMAND test_smoke)
+add_test(NAME smoke COMMAND $<TARGET_FILE:test_smoke>)

--- a/tests/smoke/CMakeLists.txt
+++ b/tests/smoke/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_executable(test_smoke test_smoke.c)
+target_link_libraries(test_smoke PRIVATE unity)
+
+add_test(NAME smoke COMMAND test_smoke)

--- a/tests/smoke/test_smoke.c
+++ b/tests/smoke/test_smoke.c
@@ -1,0 +1,31 @@
+/*
+ * Smoke test -- validates that the host-native test pipeline
+ * (CMake + Unity + CTest) is working correctly.
+ */
+
+#include "unity.h"
+
+void setUp(void)
+{
+}
+void tearDown(void)
+{
+}
+
+void test_sanity(void)
+{
+    TEST_ASSERT_TRUE(1);
+}
+
+void test_arithmetic(void)
+{
+    TEST_ASSERT_EQUAL_INT(4, 2 + 2);
+}
+
+int main(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_sanity);
+    RUN_TEST(test_arithmetic);
+    return UNITY_END();
+}


### PR DESCRIPTION
## What

Host-native unit test infrastructure using Unity v2.6.1 (via CMake FetchContent) and CTest.

## Why

Algorithm modules (rapid trigger, HRM, SOCD) are pure C with no RTOS dependencies. Testing them on the host machine provides fast feedback without hardware, and validates correctness before prototyping Stage 4.

## Scope

- [x] Firmware
- [ ] PCB / hardware
- [ ] Case / enclosure
- [ ] Docs
- [x] Tooling / CI

## How to verify

```sh
cmake -B build/tests tests/
cmake --build build/tests
ctest --test-dir build/tests
```

Should produce: `1/1 Test #1: smoke ... Passed`

## Related issues

Closes #53