### PR TITLE
Add PR status workflow for GitHub Project

### DIFF
--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -66,10 +66,8 @@ jobs:
         uses: actions/github-script@v7
         env:
           # Hallmark project (users/flwrenn/projects/12)
-          # Find via: gh project list --owner flwrenn --format json
           PROJECT_ID: PVT_kwHOBh2HNc4BPjfG
           # "End date" custom field
-          # Find via: gh project field-list 12 --owner flwrenn --format json
           END_DATE_FIELD_ID: PVTF_lAHOBh2HNc4BPjfGzg97glk
         with:
           github-token: ${{ secrets.PROJECT_TOKEN }}

--- a/.github/workflows/project-pr-status.yml
+++ b/.github/workflows/project-pr-status.yml
@@ -1,0 +1,57 @@
+name: PR status
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  set-pr-status:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set PR to PR Open
+        uses: actions/github-script@v7
+        env:
+          # Hallmark project (users/flwrenn/projects/12)
+          PROJECT_ID: PVT_kwHOBh2HNc4BPjfG
+          # "Status" single-select field
+          STATUS_FIELD_ID: PVTSSF_lAHOBh2HNc4BPjfGzg97gkw
+          # "PR Open" option
+          PR_OPEN_OPTION_ID: df73e18b
+        with:
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            const projectId = process.env.PROJECT_ID;
+            const fieldId = process.env.STATUS_FIELD_ID;
+            const prOpenOptionId = process.env.PR_OPEN_OPTION_ID;
+
+            try {
+              // Add PR to project (idempotent — returns existing item if
+              // the built-in Auto-add workflow already added it)
+              const addResult = await github.graphql(`
+                mutation($projectId: ID!, $contentId: ID!) {
+                  addProjectV2ItemById(input: {
+                    projectId: $projectId
+                    contentId: $contentId
+                  }) { item { id } }
+                }
+              `, { projectId, contentId: pr.node_id });
+
+              const prItemId = addResult.addProjectV2ItemById.item.id;
+
+              await github.graphql(`
+                mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: $projectId
+                    itemId: $itemId
+                    fieldId: $fieldId
+                    value: { singleSelectOptionId: $optionId }
+                  }) { projectV2Item { id } }
+                }
+              `, { projectId, itemId: prItemId, fieldId, optionId: prOpenOptionId });
+
+              console.log(`PR #${pr.number} → PR Open`);
+            } catch (error) {
+              core.warning(`Failed to set project status: ${error.message}`);
+            }

--- a/.github/workflows/project-pr-status.yml
+++ b/.github/workflows/project-pr-status.yml
@@ -26,32 +26,51 @@ jobs:
             const fieldId = process.env.STATUS_FIELD_ID;
             const prOpenOptionId = process.env.PR_OPEN_OPTION_ID;
 
-            try {
-              // Add PR to project (idempotent — returns existing item if
-              // the built-in Auto-add workflow already added it)
-              const addResult = await github.graphql(`
-                mutation($projectId: ID!, $contentId: ID!) {
-                  addProjectV2ItemById(input: {
-                    projectId: $projectId
-                    contentId: $contentId
-                  }) { item { id } }
+            async function findProjectItem(nodeId, attempt = 1) {
+              const result = await github.graphql(`
+                query($nodeId: ID!) {
+                  node(id: $nodeId) {
+                    ... on PullRequest {
+                      projectItems(first: 10) {
+                        nodes { id project { id } }
+                      }
+                    }
+                  }
                 }
-              `, { projectId, contentId: pr.node_id });
+              `, { nodeId });
 
-              const prItemId = addResult.addProjectV2ItemById.item.id;
+              const item = result.node.projectItems.nodes
+                .find(i => i.project.id === projectId);
 
-              await github.graphql(`
-                mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
-                  updateProjectV2ItemFieldValue(input: {
-                    projectId: $projectId
-                    itemId: $itemId
-                    fieldId: $fieldId
-                    value: { singleSelectOptionId: $optionId }
-                  }) { projectV2Item { id } }
-                }
-              `, { projectId, itemId: prItemId, fieldId, optionId: prOpenOptionId });
+              if (item) {
+                return item.id;
+              }
 
-              console.log(`PR #${pr.number} → PR Open`);
-            } catch (error) {
-              core.warning(`Failed to set project status: ${error.message}`);
+              if (attempt < 2) {
+                console.log('PR not in project yet, retrying in 5s…');
+                await new Promise(r => setTimeout(r, 5000));
+                return findProjectItem(nodeId, attempt + 1);
+              }
+
+              return null;
             }
+
+            const prItemId = await findProjectItem(pr.node_id);
+
+            if (!prItemId) {
+              core.setFailed('PR not found in project after retry');
+              return;
+            }
+
+            await github.graphql(`
+              mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $projectId
+                  itemId: $itemId
+                  fieldId: $fieldId
+                  value: { singleSelectOptionId: $optionId }
+                }) { projectV2Item { id } }
+              }
+            `, { projectId, itemId: prItemId, fieldId, optionId: prOpenOptionId });
+
+            console.log(`PR #${pr.number} → PR Open`);


### PR DESCRIPTION
## What

Add `project-pr-status.yml` GitHub Actions workflow that sets new PRs to
**PR Open** in the GitHub Project.

## Why

Automates the manual step of setting PR status in the project board.
Combined with the built-in GitHub Projects workflows:

- **Auto-add to project** — adds new issues and PRs to the project.
- **Item added to project** — sets status to **Backlog**.
- **Pull request linked to issue** — sets the linked issue to **PR Open**.
- **`project-pr-status.yml`** (this PR) — sets the PR itself to **PR Open**.

## Scope

- [ ] Firmware
- [ ] PCB / hardware
- [ ] Case / enclosure
- [ ] Docs
- [x] Tooling / CI

## How to verify

1. Enable the built-in project workflows in **Project Settings > Workflows**:
   Auto-add, Item added → Backlog, PR linked to issue → PR Open.
2. Open a test issue — it should appear in the project with status
   **Backlog**.
3. Open a test PR referencing that issue (`closes #N`) — the PR should
   appear with status **PR Open**, and the issue should be moved to
   **PR Open**.

## Related issues

Closes #68