### PR TITLE
docs: update BOM with purchase costs and sources

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -2,30 +2,30 @@
 
 ## Prototyping (Purchased)
 
-| Component | Qty | Cost |
-|-----------|-----|------|
-| A1304 Hall sensors (SOT-23) | 40 | |
-| CD74HC4051M96 MUX (SOIC-16) | 13 | |
-| 100nF caps (0805) | 100 | |
-| 100nF caps (through-hole) | 100 | |
-| Owlab Ti HE 40g switches | 50 | |
-| SuperMini NRF52840 | 3 | |
-| Kailh hotswap sockets | 40 | |
-| SOT-23 to DIP adapters | 50 | |
-| SOIC-16 to DIP-16 adapters | 20 | |
-| Pin headers 2.54mm (20 pairs) | 1 | |
-| FNIRSI HS-01 soldering iron (6 tips) | 1 | |
-| ANENG SZ302 multimeter | 1 | |
-| Kester 951 flux pen (x2) | 1 | |
-| 63/37 solder 0.6mm 50g | 1 | |
-| Solder wick 2.0mm | 1 | |
-| Breadboard 830-point (MB-102) | 1 | |
-| Jumper wires (M-M, M-F) | 1 | |
-| Brass wool tip cleaner | 1 | |
-| Headband magnifier | 1 | |
-| SMD practice kit | 1 | |
-| Shipping | | |
-| **Total** | | |
+All prototyping parts purchased. Costs normalised to EUR (LCSC USD converted at ~0.92 EUR/USD).
+
+| Component | Qty | Source | Cost |
+|-----------|-----|--------|------|
+| A1304 Hall sensors (SOT-23) | 40 | LCSC | €23.78 |
+| CD74HC4051M96 MUX (SOIC-16) | 13 | LCSC | €3.51 |
+| 100nF caps (0805) | 100 | LCSC | €0.48 |
+| 100nF caps (through-hole) | 100 | AliExpress | €1.08 |
+| Owlab Ti HE 40g switches | 50 | AliExpress | €22.99 |
+| SuperMini NRF52840 | 3 | AliExpress | €6.78 |
+| Kailh hotswap sockets | 40 | AliExpress | €3.39 |
+| SOT-23 to DIP adapters | 50 | AliExpress | €2.37 |
+| SOIC-16 to DIP-16 adapters | 20 | AliExpress | €1.85 |
+| Pin headers 2.54mm (20 pairs) | 1 | AliExpress | €1.80 |
+| FNIRSI HS-01 soldering iron (6 tips) | 1 | AliExpress | €38.19 |
+| ANENG SZ302 multimeter | 1 | AliExpress | €12.19 |
+| Kester 951 flux pen (x2) | 1 | AliExpress | €4.29 |
+| 63/37 solder 0.6mm 50g | 1 | AliExpress | €1.17 |
+| Solder wick 2.0mm | 1 | AliExpress | €1.19 |
+| Breadboard 830-point + jumper wires | 1 | AliExpress | €3.62 |
+| Brass wool tip cleaner | 1 | AliExpress | €1.95 |
+| Headband magnifier | 1 | AliExpress | €10.99 |
+| SMD practice kit | 1 | AliExpress | €2.12 |
+| **Total** | | | **~€144** |
 
 ### Breadboard Strategy
 
@@ -34,23 +34,19 @@ All purchased components are SMD. For breadboard prototyping:
 - **CD74HC4051M96 (SOIC-16)** -> solder onto SOIC-16 to DIP-16 adapters. Use 2-3 for proto, keep 6 for PCB.
 - Start with SMD practice kit before real components.
 
-## Final Build (Per Half)
+## Final Build
 
 Order after prototyping passes.
 
-| Component | Qty |
-|-----------|-----|
-| nRF52840 (SuperMini or bare) | 1 |
-| Owlab Ti HE 40g | 18 |
-| A1304 Hall sensor | 18 |
-| CD74HC4051 MUX | 3 |
-| 100nF caps | ~25 |
-| Kailh hotswap socket | 18 |
-| 703040 LiPo 750mAh | 1 |
-| JST PH 2.0, SPDT switch, TRRS, USB-C, reset button, ESD protection | 1 ea |
-| Custom PCB + 3D printed case | 1 ea |
-| XIAO nRF52840 dongle | 1 |
-| Keycaps (DSA 1U x36) | 36 |
-| J-Link EDU Mini | 1 |
+| Component | ~Cost |
+|-----------|-------|
+| XIAO nRF52840 dongle | €10 |
+| PCBs (JLCPCB, 5 sets) | €25 |
+| 703040 LiPo 750mAh x2 (JST PH-2.0) | €6 |
+| Passive components, connectors | €13 |
+| Keycaps (DSA 1U x36) | €18 |
+| 3D printed case x2 | €10 |
+| J-Link EDU Mini | €20 |
+| **Total** | **~€102** |
 
-Sensors, switches, hotswap sockets, MUX, caps already covered by prototyping purchase.
+Sensors, switches, hotswap sockets, MUX, caps already purchased.


### PR DESCRIPTION
## What

Update `docs/components.md` with actual purchase costs, sources, and a revised final build list based on the prototyping plan.

## Why

The BOM had no costs or supplier info filled in. This brings it in line with actual purchase records so costs are tracked and the final build estimate is realistic.

## Scope

- [ ] Firmware
- [ ] PCB / hardware
- [ ] Case / enclosure
- [x] Docs
- [ ] Tooling / CI

## How to verify

Review `docs/components.md` — prototyping table should have Source and Cost columns (all EUR), final build table should list remaining items with estimated costs.

## Related issues

None.