### PR TITLE
Fix PR status workflow retry logic and non-fatal exit

### DIFF
--- a/.github/workflows/project-pr-status.yml
+++ b/.github/workflows/project-pr-status.yml
@@ -26,6 +26,9 @@ jobs:
             const fieldId = process.env.STATUS_FIELD_ID;
             const prOpenOptionId = process.env.PR_OPEN_OPTION_ID;
 
+            const MAX_ATTEMPTS = 5;
+            const BASE_DELAY_MS = 3000;
+
             async function findProjectItem(nodeId, attempt = 1) {
               const result = await github.graphql(`
                 query($nodeId: ID!) {
@@ -39,26 +42,33 @@ jobs:
                 }
               `, { nodeId });
 
-              const item = result.node.projectItems.nodes
-                .find(i => i.project.id === projectId);
+              const nodes = result.node.projectItems.nodes;
+              const item = nodes.find(i => i.project.id === projectId);
 
               if (item) {
-                return item.id;
+                return { itemId: item.id, projectItems: nodes };
               }
 
-              if (attempt < 2) {
-                console.log('PR not in project yet, retrying in 5s…');
-                await new Promise(r => setTimeout(r, 5000));
+              if (attempt < MAX_ATTEMPTS) {
+                const delay = BASE_DELAY_MS * Math.pow(2, attempt - 1);
+                console.log(`PR not in project yet (attempt ${attempt}/${MAX_ATTEMPTS}), retrying in ${delay / 1000}s…`);
+                await new Promise(r => setTimeout(r, delay));
                 return findProjectItem(nodeId, attempt + 1);
               }
 
-              return null;
+              return { itemId: null, projectItems: nodes };
             }
 
-            const prItemId = await findProjectItem(pr.node_id);
+            const { itemId: prItemId, projectItems } = await findProjectItem(pr.node_id);
 
             if (!prItemId) {
-              core.setFailed('PR not found in project after retry');
+              const foundIds = projectItems.map(i => i.project.id);
+              core.warning(
+                `PR #${pr.number} not found in project ${projectId} after ${MAX_ATTEMPTS} attempts. ` +
+                `Found ${projectItems.length} project item(s)` +
+                (foundIds.length ? ` in project(s): ${foundIds.join(', ')}` : '') +
+                '. Verify project automation and token permissions.'
+              );
               return;
             }
 

--- a/.github/workflows/project-pr-status.yml
+++ b/.github/workflows/project-pr-status.yml
@@ -42,7 +42,7 @@ jobs:
                 }
               `, { nodeId });
 
-              const nodes = result.node.projectItems.nodes;
+              const nodes = result.node?.projectItems?.nodes ?? [];
               const item = nodes.find(i => i.project.id === projectId);
 
               if (item) {

--- a/.github/workflows/project-pr-status.yml
+++ b/.github/workflows/project-pr-status.yml
@@ -29,6 +29,11 @@ jobs:
             const MAX_ATTEMPTS = 5;
             const BASE_DELAY_MS = 3000;
 
+            function isTransient(error) {
+              if (!error.status) return true;
+              return [429, 502, 503, 504].includes(error.status);
+            }
+
             async function findProjectItem(nodeId, attempt = 1) {
               let result;
               try {
@@ -45,11 +50,13 @@ jobs:
                 `, { nodeId });
               } catch (error) {
                 console.log(`GraphQL query failed (attempt ${attempt}/${MAX_ATTEMPTS}): ${error.message}`);
-                return { itemId: null, projectItems: [], error: error.message };
+                if (!isTransient(error)) {
+                  return { itemId: null, projectItems: [], error: error.message, attempts: attempt };
+                }
               }
 
-              const nodes = result.node?.projectItems?.nodes ?? [];
-              const item = nodes.find(i => i.project.id === projectId);
+              const nodes = result?.node?.projectItems?.nodes ?? [];
+              const item = nodes.find(i => i?.project?.id === projectId);
 
               if (item) {
                 return { itemId: item.id, projectItems: nodes };
@@ -62,15 +69,15 @@ jobs:
                 return findProjectItem(nodeId, attempt + 1);
               }
 
-              return { itemId: null, projectItems: nodes };
+              return { itemId: null, projectItems: nodes, attempts: attempt };
             }
 
-            const { itemId: prItemId, projectItems, error } = await findProjectItem(pr.node_id);
+            const { itemId: prItemId, projectItems, error, attempts } = await findProjectItem(pr.node_id);
 
             if (!prItemId) {
-              const foundIds = projectItems.map(i => i.project.id);
+              const foundIds = projectItems.map(i => i?.project?.id).filter(Boolean);
               core.warning(
-                `PR #${pr.number} not found in project ${projectId} after ${MAX_ATTEMPTS} attempts. ` +
+                `PR #${pr.number} not found in project ${projectId} after ${attempts} attempt(s). ` +
                 `Found ${projectItems.length} project item(s)` +
                 (foundIds.length ? ` in project(s): ${foundIds.join(', ')}` : '') +
                 '. Verify project automation and token permissions.' +

--- a/.github/workflows/project-pr-status.yml
+++ b/.github/workflows/project-pr-status.yml
@@ -30,17 +30,23 @@ jobs:
             const BASE_DELAY_MS = 3000;
 
             async function findProjectItem(nodeId, attempt = 1) {
-              const result = await github.graphql(`
-                query($nodeId: ID!) {
-                  node(id: $nodeId) {
-                    ... on PullRequest {
-                      projectItems(first: 10) {
-                        nodes { id project { id } }
+              let result;
+              try {
+                result = await github.graphql(`
+                  query($nodeId: ID!) {
+                    node(id: $nodeId) {
+                      ... on PullRequest {
+                        projectItems(first: 10) {
+                          nodes { id project { id } }
+                        }
                       }
                     }
                   }
-                }
-              `, { nodeId });
+                `, { nodeId });
+              } catch (error) {
+                console.log(`GraphQL query failed (attempt ${attempt}/${MAX_ATTEMPTS}): ${error.message}`);
+                return { itemId: null, projectItems: [], error: error.message };
+              }
 
               const nodes = result.node?.projectItems?.nodes ?? [];
               const item = nodes.find(i => i.project.id === projectId);
@@ -59,7 +65,7 @@ jobs:
               return { itemId: null, projectItems: nodes };
             }
 
-            const { itemId: prItemId, projectItems } = await findProjectItem(pr.node_id);
+            const { itemId: prItemId, projectItems, error } = await findProjectItem(pr.node_id);
 
             if (!prItemId) {
               const foundIds = projectItems.map(i => i.project.id);
@@ -67,20 +73,26 @@ jobs:
                 `PR #${pr.number} not found in project ${projectId} after ${MAX_ATTEMPTS} attempts. ` +
                 `Found ${projectItems.length} project item(s)` +
                 (foundIds.length ? ` in project(s): ${foundIds.join(', ')}` : '') +
-                '. Verify project automation and token permissions.'
+                '. Verify project automation and token permissions.' +
+                (error ? ` Error: ${error}` : '')
               );
               return;
             }
 
-            await github.graphql(`
-              mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
-                updateProjectV2ItemFieldValue(input: {
-                  projectId: $projectId
-                  itemId: $itemId
-                  fieldId: $fieldId
-                  value: { singleSelectOptionId: $optionId }
-                }) { projectV2Item { id } }
-              }
-            `, { projectId, itemId: prItemId, fieldId, optionId: prOpenOptionId });
+            try {
+              await github.graphql(`
+                mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: $projectId
+                    itemId: $itemId
+                    fieldId: $fieldId
+                    value: { singleSelectOptionId: $optionId }
+                  }) { projectV2Item { id } }
+                }
+              `, { projectId, itemId: prItemId, fieldId, optionId: prOpenOptionId });
+            } catch (error) {
+              core.warning(`Failed to set PR #${pr.number} to PR Open: ${error.message}`);
+              return;
+            }
 
             console.log(`PR #${pr.number} → PR Open`);


### PR DESCRIPTION
## What

Improve the `project-pr-status.yml` workflow with exponential backoff retries, null-safe GraphQL response handling, and a non-fatal exit path when the PR isn't found in the GitHub Project.

## Why

The workflow previously failed the check (`core.setFailed(...)`) if the PR wasn't added to the project within ~5 seconds. Since GitHub project automation is asynchronous, this caused intermittent failing checks that could block merges. Now uses 5 attempts with exponential backoff (3s, 6s, 12s, 24s — ~45s total window) and logs a warning instead of failing when the item isn't found. GraphQL responses are null-safe so token/permission issues also reach the warning path instead of throwing.

## Scope

- [ ] Firmware
- [ ] PCB / hardware
- [ ] Case / enclosure
- [ ] Docs
- [x] Tooling / CI

## How to verify

1. Open a test PR and observe the workflow run.
2. The "Set PR to PR Open" step should retry with logged delays if the project item isn't immediately available.
3. If the item is never found after 5 attempts, the step should complete with a warning (not a failure).

## Related issues

None — split out from #65 to keep that PR scoped to firmware.