### PR TITLE
Update project status with partial delivery info

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -18,10 +18,12 @@ body:
       multiple: true
       options:
         - Firmware
-        - PCB / hardware
-        - Case / enclosure
-        - Docs
+        - Pcb
+        - Case
+        - Hardware
         - Tooling / CI
+        - Documentation
+        - Test
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -18,10 +18,12 @@ body:
       multiple: true
       options:
         - Firmware
-        - PCB / hardware
-        - Case / enclosure
-        - Docs
+        - Pcb
+        - Case
+        - Hardware
         - Tooling / CI
+        - Documentation
+        - Test
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -18,10 +18,12 @@ body:
       multiple: true
       options:
         - Firmware
-        - PCB / hardware
-        - Case / enclosure
-        - Docs
+        - Pcb
+        - Case
+        - Hardware
         - Tooling / CI
+        - Documentation
+        - Test
     validations:
       required: true
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,10 +9,12 @@
 ## Scope
 
 - [ ] Firmware
-- [ ] PCB / hardware
-- [ ] Case / enclosure
-- [ ] Docs
+- [ ] Pcb
+- [ ] Case
+- [ ] Hardware
 - [ ] Tooling / CI
+- [ ] Documentation
+- [ ] Test
 
 ## How to verify
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Wireless Hall Effect 36-key split keyboard. Analog sensing, rapid trigger, depth-based home row mods, 1ms LLPM wireless.
 
-**Status:** Prototyping (parts ordered, waiting for delivery)
+**Status:** Prototyping (AliExpress parts delivered; waiting on LCSC shipment — Hall sensors, MUX, caps)
 
 ## Specs
 


### PR DESCRIPTION
## What

Update the README status line to reflect that AliExpress parts have been delivered while LCSC shipment (Hall sensors, MUX, caps) is still pending.

## Why

The previous status said "parts ordered, waiting for delivery" which is no longer accurate — all AliExpress items have arrived. This makes it clear exactly what is still blocking prototyping Stage 1.

## Scope

- [ ] Firmware
- [ ] Pcb
- [ ] Case
- [ ] Hardware
- [ ] Tooling / CI
- [x] Documentation
- [ ] Test

## How to verify

Check `README.md` line 5 for the updated status string.

## Related issues

None.